### PR TITLE
fix: add --overwrite_output_dir to config file

### DIFF
--- a/code/config/base_config.yaml
+++ b/code/config/base_config.yaml
@@ -1,5 +1,5 @@
 model:
-  model_name_or_path: models/roberta_finetune # klue/roberta-large # models/roberta_original 훈련할때 쓸 모델명이나, 이어서 훈련하거나 추론할 모델경로
+  model_name_or_path: klue/roberta-large # klue/roberta-large # models/roberta_original 훈련할때 쓸 모델명이나, 이어서 훈련하거나 추론할 모델경로
   config_name: null
   tokenizer_name: null
   retrieval_tokenizer: monologg/koelectra-base-v3-finetuned-korquad # BM25로 retrieve할때만 쓰는 토크나이저 이름
@@ -28,15 +28,16 @@ train:
   logging_step: 500 # 1000 # 500
   save_step: 500
   gradient_accumulation: 1
-  do_train: False
+  do_train: True
   do_eval: False
-  do_predict: True
-  train_output_dir: models/roberta_finetune # roberta_korquad
-  inference_output_dir: outputs/roberta_finetune
+  do_predict: False
+  train_output_dir: models/roberta-large # roberta_korquad
+  inference_output_dir: outputs/roberta-large
   seed: 42
   save_total_limit: 1 # 학습 중 저장할 모델의 최대 개수. 설정된 개수만큼 저장되면, 새로운 모델을 저장할 때 성능이 좋은 모델을 남기고 성능이 떨어지는 모델은 자동으로 삭제됨.
+  overwrite_output_dir: False
 
 wandb:
   use: True
   project: odqa
-  name: roberta_finetune # model_name_epoch_bs_learning_rate이 wandb name으로 붙는데 그 앞에 붙을 접두어
+  name: yunseo # model_name_epoch_bs_learning_rate이 wandb name으로 붙는데 그 앞에 붙을 접두어

--- a/code/train.py
+++ b/code/train.py
@@ -45,7 +45,8 @@ def main(config):
         logging_steps=tr_args.logging_step,
         save_steps=tr_args.save_step,
         load_best_model_at_end=True,
-        metric_for_best_model='exact_match'
+        metric_for_best_model='exact_match',
+        overwrite_output_dir=tr_args.overwrite_output_dir,
     )
 
     if config.wandb.use:


### PR DESCRIPTION
## Overview
- #13 Issue에 따른 해결책

## Change Log
- train.py의 trainingargs에 overwrite_output_dir추가하고
- config file에도 overwrite_output_dir를 추가했음
- overwrite_output_dir를 사용하려면 config fle에서 시정해주면 됨

## To Reviewer
- config file은 계속 바뀌는 거니깐 나머지 속성들은 바껴도 무시해도 되겠지?

## Issue Tags
- Closed | Fixed: #13 
- See also: #
