### PR TITLE
fix: delete nonexistent save_last option from TrainingArguments

### DIFF
--- a/code/train.py
+++ b/code/train.py
@@ -47,7 +47,6 @@ def main(config):
         load_best_model_at_end=True,
         metric_for_best_model='exact_match',
         overwrite_output_dir=tr_args.overwrite_output_dir,
-        save_last=True,
     )
 
     if config.wandb.use:


### PR DESCRIPTION
## Overview
- save_last 옵션이 TrainingArguments에 존재하지 않는 인자라서 삭제합니다.